### PR TITLE
Support deploying to heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: npm start

--- a/app/ws/RadioTower.js
+++ b/app/ws/RadioTower.js
@@ -12,8 +12,8 @@ module.exports = {
 
   initRedis( ) {
     winston.debug( chalk.magenta( 'Initialising redis in radio tower.' ) )
-    this.publisher = redis.createClient( CONFIG.redis.port, CONFIG.redis.url )
-    this.subscriber = redis.createClient( CONFIG.redis.port, CONFIG.redis.url )
+    this.publisher = redis.createClient( CONFIG.redis.url )
+    this.subscriber = redis.createClient( CONFIG.redis.url )
 
     this.subscriber.subscribe( 'ws-broadcast' )
     this.subscriber.subscribe( 'ws-message' )

--- a/config.js
+++ b/config.js
@@ -8,11 +8,10 @@ module.exports = {
     indentResponses: process.env.INDENT_RESPONSES == 'true' ? true : false
   },
   mongo: {
-    url: process.env.MONGO_URI ? process.env.MONGO_URI : 'mongodb://mongo:27017/speckle'
+    url: process.env.MONGODB_URI || process.env.MONGO_URI || 'mongodb://mongo:27017/speckle'
   },
   redis: {
-    port: process.env.REDIS_PORT ? process.env.REDIS_PORT : '6379',
-    url: process.env.REDIS_ADDR ? process.env.REDIS_ADDR : 'redis'
+    url: process.env.REDIS_URL || `redis://${process.env.REDIS_ADDR || 'redis'}:${process.env.REDIS_PORT || '6379'}`
   },
   sessionSecret: 'NaturalSparklingWaterMineral'
 }

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,14 @@ Steps:
 
 3) Visit your speckle server [http://localhost](http://localhost) or whatever the IP address of your VPS is.
 
+### Deploying to Heroku
+
+    $ heroku create --stack cedar
+    $ heroku addons:create mongolab:sandbox
+    $ heroku addons:create heroku-redis:hobby-dev
+    $ git push heroku master
+    $ heroku open
+
 ## Develop
 More detailed instructions coming soon. Simply spin off an instance of Redis & Mongo locally, make sure in `config.js` that you're connecting to them, and spin out the server with `nodemon server.js` if  you want live reloads or `node server.js` otherwise. 
 

--- a/server.js
+++ b/server.js
@@ -74,7 +74,7 @@ if ( cluster.isMaster ) {
 
   if ( CONFIG.serverDescription.indentResponses )
     app.set( 'json spaces', 2 )
-  
+
   require( './.config/passport' )( passport )
 
   ////////////////////////////////////////////////////////////////////////
@@ -105,7 +105,8 @@ if ( cluster.isMaster ) {
   /// LAUNCH                                                         /////.
   ////////////////////////////////////////////////////////////////////////
 
-  server.listen( 3000, ( ) => {
-    winston.info( 'Speckle worker process now running.' )
+  var port = process.env.PORT || 3000
+  server.listen( port, ( ) => {
+    winston.info( `Speckle worker process now running on port ${port}.` )
   } )
 }


### PR DESCRIPTION
* Adds a simple procfile
* Adds REDIS_URL and MONGODB_URI for configuration of redis and mongo on
  heroku (provisioned add-ons automatically populate these env vars)
* REDIS_URL takes full URI to redis server (falls back to
  REDIS_ADDR/REDIS_PORT)
* MONGODB_URI preferred over MONGO_URI
* Binds express to $PORT, if present

See #51