### PR TITLE
Updated broken API docs link

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -77,7 +77,7 @@ Note: You're not restricted to digital ocean. Any machine with docker should be 
        $ node server.js
 
 ## API
-[API docs are here](https://speckleworks.github.io/SpeckleOpenApi/#introduction) - they are a good overview of what you can do with the speckle server.
+[API docs are here](https://speckleworks.github.io/SpeckleSpecs/) - they are a good overview of what you can do with the speckle server.
 
 ## Current Limitations
 


### PR DESCRIPTION
I'm not 100% sure this is the correct link, but the old one is broken...