### PR TITLE
Allow server to bind to specific ip's

### DIFF
--- a/.env-base
+++ b/.env-base
@@ -26,6 +26,10 @@ PLUGIN_DIRS="./node_modules/@speckle,./plugins"
 # if you have any firewalls set up (ie, ufw).
 PORT=3000
 
+# IP: The ip to listen to
+# Defaults to all IPs bound to this machine, and all IPv6 IPs if IPv6 is enabled.
+#IP=127.0.0.1
+
 # MAX_PROC: The maximum amount of service workers to start. If this is not specified,
 # Speckle will fork out as many as the machine's processor cores. To specify it,
 # just uncomment the line below.

--- a/.env-base
+++ b/.env-base
@@ -27,8 +27,9 @@ PLUGIN_DIRS="./node_modules/@speckle,./plugins"
 PORT=3000
 
 # IP: The ip to listen to
-# Defaults to all IPs bound to this machine, and all IPv6 IPs if IPv6 is enabled.
-#IP=127.0.0.1
+# Defaults to all IPs bound to this machine, and all IPv6 IPs if IPv6 is enabled. 
+# If you want to bind to IPv4 only, or a specific IPv6/v4 address, uncomment the line below and specifiy your preferred address.
+# IP=127.0.0.1
 
 # MAX_PROC: The maximum amount of service workers to start. If this is not specified,
 # Speckle will fork out as many as the machine's processor cores. To specify it,

--- a/server.js
+++ b/server.js
@@ -128,7 +128,8 @@ if ( cluster.isMaster ) {
   /// /////////////////////////////////////////////////////////////////////
 
   var port = process.env.PORT || 3000
-  server.listen( port, ( ) => {
+  var ip = process.env.IP || null
+  server.listen( port, ip, ( ) => {
     logger.debug( chalk.yellow( `Speckle worker process ${process.pid} now running on port ${port}.` ) )
   } )
 }


### PR DESCRIPTION
**Problem**: If IPv6 is enabled on a machine, by default nodejs will bind to IPv6. You may not want to bind only to IPv6 in all situations.

This behaviour is described in the nodejs manual:
https://nodejs.org/api/net.html#net_server_listen_port_host_backlog_callback

> If host is omitted, the server will accept connections on the unspecified IPv6 address (::) when IPv6 is available, or the unspecified IPv4 address (0.0.0.0) otherwise.
> 
> In most operating systems, listening to the unspecified IPv6 address (::) may cause the net.Server to also listen on the unspecified IPv4 address (0.0.0.0).


**Solution**
Adding an IP variable to the .env file, and listening to this ip in server.js