### PR TITLE
Revised environment in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,8 @@ services:
       - REDIS_URL=redis://redis:6379
       - EXPOSE_EMAILS=false
       - PUBLIC_STREAMS=true
-      - PLUGIN_DIRS="./node_modules/@speckle,./plugins"
+      - PLUGIN_DIRS=./node_modules/@speckle,./plugins
+      - CANONICAL_URL=http://localhost:3000
     links:
       - redis
       - mongo


### PR DESCRIPTION
1. PLUGIN_DIRS in docker-compose.yml was including the quotation marks as part of the plugin directory path.

Before:

![image](https://user-images.githubusercontent.com/193290/60686830-f68f7c80-9ea2-11e9-9be0-f052c5940591.png)

After:

![image](https://user-images.githubusercontent.com/193290/60686871-1d4db300-9ea3-11e9-8b4f-525110ba2bef.png)

2. Without CANONICAL_URL set http://locahost:3000/api was prefixing the routes with "undefined" which was bugging me...