### PR TITLE
Fix docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,8 @@ version: '3'
 services:
   # SPECKLE
   speckle:
-    # image: speckle/speckleserver:latest
-    image: speckle:latest
+    image: speckle/speckleserver:latest
+    #image: speckle:latest # local dev
     ports:
       - '3000:3000'
     networks:
@@ -24,7 +24,7 @@ services:
       - REDIS_URL=redis://redis:6379
       - EXPOSE_EMAILS=false
       - PUBLIC_STREAMS=true
-      - PLUGIN_DIRS="./node_modules/@speckle,./plugins"
+      - PLUGIN_DIRS=./node_modules/@speckle,./plugins
     links:
       - redis
       - mongo


### PR DESCRIPTION
A couple of changes that I had to make to deploy just now...

1. I was getting the following warnings

    ```
    speckle_1  | 2019-08-14 18:39:40 warn: specified plugin directory does not exist: "./node_modules/@speckle
    speckle_1  | 2019-08-14 18:39:40 warn: specified plugin directory does not exist: ./plugins"
    ```

2. `speckle:latest` doesn't exist on Docker Hub. I assume it was used for local development.

Aside from that, smooth as butter!!