### PR TITLE
Allow signin to use postMessage() to communicate token

### DIFF
--- a/.env-base
+++ b/.env-base
@@ -129,7 +129,7 @@ GITHUB_CALLBACK="CHANGE_ME"
 
 # Whitelisted domains
 # Add here any other places that you trust this server to redirect to once authentication is done.
-REDIRECT_URLS="http://localhost:5050,https://app.speckle.systems"
+REDIRECT_URLS="http://localhost:5050,https://localhost:8080,https://app.speckle.systems"
 
 # Wether to allow non http*s* redirect urls.
 # "localhost" redirect urls will always work with or without TLS.

--- a/views/postLogin.hbs
+++ b/views/postLogin.hbs
@@ -41,7 +41,9 @@
     }
 
     if( redirectUrl && redirectUrl !== '') {
-      if( window.opener ) {
+      if( window.parent && window.parent !== window ) {
+        window.parent.postMessage("{{connectionString}}", "{{redirectUrl}}")
+      } else if( window.opener ) {
         window.opener.location.href = "{{redirectUrl}}?token={{connectionString}}"
         self.close()
       } else {


### PR DESCRIPTION
Changes:
- Added an HTTPS localhost in the whitelisted redirect URL list for debugging purposes
- If the signin window is not the top most window (i.e., iframe), it will use postMessage() with the target origin being the redirectUrl. Useful for embedding in iframes.