### PR TITLE
fix(docker): Fix up docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,32 +8,31 @@ services:
       - '3000:3000'
     networks:
       - webnet
+    #restart: always
     depends_on:
       - redis
       - mongo
     environment:
       # Please see the example .env file provided for how to properly configure this.
       # https://github.com/speckleworks/SpeckleServer/blob/master/.env-base
-      - SERVER_NAME="Docker Speckle Server"
-      - CANONICAL_URL="http://localhost:3000"
-      - SESSION_SECRET="Change Me"
+      - SERVER_NAME=Docker Speckle Server
+      - CANONICAL_URL=http://localhost:3000
+      - SESSION_SECRET=change_me
+      # optional
       - MAX_PROC=1
-      - CANONICAL_URL="http://localhost:3000"
       - PUBLIC_STREAMS=true
-      - PLUGIN_DIRS="./node_modules/@speckle,./plugins"
+      - PLUGIN_DIRS=./node_modules/@speckle,./plugins
       - PORT=3000
       - IP=0.0.0.0
-      - MAX_PROC=1
       - REQ_SIZE=10mb
-      - SESSION_SECRET=":D"
-      - MONGODB_URI="mongodb://localhost:27017/speckle_v3"
-      - REDIS_URL="redis://localhost:6379"
+      - MONGODB_URI=mongodb://mongo:27017/speckle_v3
+      - REDIS_URL=redis://redis:6379
       - INDENT_RESPONSES=false
       - EXPOSE_EMAILS=true
       - FIRST_USER_ADMIN=true
       - PUBLIC_REGISTRATION=true
       - USE_LOCAL=true
-      - REDIRECT_URLS="https://app.speckle.systems"
+      - REDIRECT_URLS=https://app.speckle.systems
     links:
       - redis
       - mongo


### PR DESCRIPTION
Just redeployed speckle via docker (19.03.1, ubuntu 18.04) and noticed a few things...

* `CANONICAL_URL`, `SESSION_SECRET` and `MAX_PROC` were duplicated
* quotes around env var values don't get stripped, so you end up with errors like `specified plugin directory does not exist: ./plugins"` (previously fixed in #150)
* mongodb and redis fail to connect unless you use their docker-compose networking hostnames
* made it clearer that you only need to tweak `SERVER_NAME`, `CANONICAL_URL` and `SESSION_SECRET` to get a working speckle server

Closes #135