### PR TITLE
build(docker): deploy latest tag with new release

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,3 +15,10 @@ deploy.sh
 docker-compose.yml
 *.md
 releaserc.json
+
+.nyc_output
+node_modules/
+logs/
+*.sublime-project
+*.sublime-workspace
+npm-debug.log

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ tree_out.txt
 
 #don't track our super secret speckle stuff™ file
 .env
+
+.nyc_output

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ WORKDIR /usr/src/app
 
 # INSTALL
 COPY package*.json ./
-RUN npm install
+RUN npm install --only=prod
 # GET PLUGINS
 RUN mkdir -p plugins/admin
 RUN git clone https://github.com/speckleworks/SpeckleAdmin.git plugins/admin

--- a/deploy.sh
+++ b/deploy.sh
@@ -14,7 +14,9 @@ echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 
 # Build the docker image
 docker build -t $IMAGE_TAG .
+docker build -t $DOCKER_IMAGE:latest .
+
 # Push the image with the new version tag
 docker push $IMAGE_TAG
 # Push the image with the "latest" version tag
-docker push $IMAGE
+docker push $DOCKER_IMAGE:latest


### PR DESCRIPTION
Also forced "prod only" npm package install + more comprehensive .dockerignore to reduce image size.

#186