### PR TITLE
fix(api): set api version from env var

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -15,6 +15,7 @@ deploy.sh
 docker-compose.yml
 *.md
 releaserc.json
+.git
 
 .nyc_output
 node_modules/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,6 @@
 # NODE
 FROM node:10
 
-# LABELS
-LABEL version="1.x.x"
-LABEL description="Speckle Server Docker Container Image"
-
 # CREATE DIRS
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
@@ -21,4 +17,15 @@ RUN git clone https://github.com/speckleworks/SpeckleAdmin.git plugins/admin
 # RUN git clone https://github.com/speckleworks/SpeckleViewer.git plugins/viewer
 
 COPY . .
+
+# Version tag
+ARG GIT_TAG
+
+# LABELS
+LABEL version=GIT_TAG
+LABEL description="Speckle Server Docker Container Image"
+
+# Fixed Env Vars
+ENV SPECKLE_API_VERSION ${GIT_TAG:-UNKNOWN}
+
 CMD ["node", "server.js"]

--- a/app/api/index.js
+++ b/app/api/index.js
@@ -216,15 +216,7 @@ module.exports = function ( app, express, urlRoot, plugins ) {
     if ( r.route.includes( 'objects' ) ) grouped.objects.push( r )
   } )
 
-  let tagVersion = null
-  try {
-    exec( 'git describe --tags', ( err, stdout ) => {
-      tagVersion = stdout.split( '-' )[ 0 ].replace( /(\r\n|\n|\r)/gm, "" )
-    } )
-  } catch ( err ) {
-    // POKEMON
-    tagVersion = '1.x.x'
-  }
+  let tagVersion = process.env.SPECKLE_API_VERSION || '1.x.x'
 
   r.get( '/', ( req, res ) => {
     let serverDescription = {

--- a/app/api/index.js
+++ b/app/api/index.js
@@ -1,6 +1,5 @@
 const passport = require( 'passport' )
 const adminCheck = require( './middleware/AdminCheck' )
-const { exec } = require( 'child_process' )
 
 module.exports = function ( app, express, urlRoot, plugins ) {
 

--- a/deploy.sh
+++ b/deploy.sh
@@ -13,8 +13,9 @@ fi
 echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 
 # Build the docker image
-docker build -t $IMAGE_TAG .
-docker build -t $DOCKER_IMAGE:latest .
+docker build . -t $IMAGE_TAG --build-arg GIT_TAG=${1}
+# Create the same image with tag latest
+docker tag $IMAGE_TAG $DOCKER_IMAGE:latest
 
 # Push the image with the new version tag
 docker push $IMAGE_TAG


### PR DESCRIPTION
use "SPECKLE_API_VERSION" env var to set the API version that appears on the "/api" endpoint. This
environment variable is set automatically for docker containers.

fix #200