### PR TITLE
fix(models/DataStream.js): setting private property of streams

### DIFF
--- a/models/DataStream.js
+++ b/models/DataStream.js
@@ -6,7 +6,7 @@ var dataStreamSchema = mongoose.Schema( {
 
   // ownership & permissions
   owner: { type: mongoose.Schema.Types.ObjectId, ref: 'User' },
-  private: { type: Boolean, default: !process.env.PUBLIC_STREAMS },
+  private: { type: Boolean, default: !( process.env.PUBLIC_STREAMS === 'true' ) },
   canRead: [ { type: mongoose.Schema.Types.ObjectId, ref: 'User' } ],
   canWrite: [ { type: mongoose.Schema.Types.ObjectId, ref: 'User' } ],
   anonymousComments: { type: Boolean, default: false },


### PR DESCRIPTION
This PR fixes setting the default value for streams to `private` if the environment variable says so. Issue was that `ENV_VAR_X=true` get read into node as `"true"`. 